### PR TITLE
:bug: :lipstick: Fix width for Team Member Cards

### DIFF
--- a/src/components/TeamMemberCard.js
+++ b/src/components/TeamMemberCard.js
@@ -19,7 +19,7 @@ export default function TeamMemberCard({
 		<Fade cascade>
 			<li
 				key={id}
-				className="w-47pct md:w-28pct xl:w-22pct xl:max-w-22pct"
+				className="375wide:w-46pct md:w-28pct xl:w-22pct xl:max-w-22pct"
 			>
 				<img
 					className="rounded w-full"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
 	darkMode: "class",
 	theme: {
 		screens: {
+			"375wide": "375px",
 			"457wide": "457px",
 			sm: "640px",
 			md: "768px",
@@ -68,7 +69,7 @@ module.exports = {
 			width: {
 				"22pct": "22%",
 				"28pct": "28%",
-				"47pct": "47%",
+				"46pct": "46%",
 			},
 
 			maxWidth: {


### PR DESCRIPTION
- Adjust the width styles at the 375-pixel-wide breakpoint to remove awkward padding for mobile-first design & development